### PR TITLE
Add SessionStart hook to provision R for cloud sessions

### DIFF
--- a/.claude/hooks/install-r-deps.R
+++ b/.claude/hooks/install-r-deps.R
@@ -13,6 +13,12 @@ if (!requireNamespace("devtools", quietly = TRUE)) {
   install.packages("devtools")
 }
 
+# install_dev_deps() shells out to remotes, which isn't a hard dependency
+# of devtools itself.
+if (!requireNamespace("remotes", quietly = TRUE)) {
+  install.packages("remotes")
+}
+
 # Installs DESCRIPTION's Imports/Depends/Suggests plus devtools' own
 # recommended tooling (roxygen2, testthat, etc.).
 devtools::install_dev_deps(dependencies = TRUE, upgrade = "never")

--- a/.claude/hooks/install-r-deps.R
+++ b/.claude/hooks/install-r-deps.R
@@ -1,0 +1,24 @@
+# Installs hdatools' R dev toolchain for a Claude Code on the web session.
+# Called from session-start.sh after system packages (r-base, pandoc, and
+# the compiled-package system libs) are in place.
+
+repos <- c(
+  P3M = "https://packagemanager.posit.co/cran/__linux__/noble/latest",
+  CRAN = "https://cloud.r-project.org"
+)
+options(repos = repos)
+
+if (!requireNamespace("devtools", quietly = TRUE)) {
+  install.packages("devtools")
+}
+
+# Installs DESCRIPTION's Imports/Depends/Suggests plus devtools' own
+# recommended tooling (roxygen2, testthat, etc.).
+devtools::install_dev_deps(dependencies = TRUE, upgrade = "never")
+
+# Used by the release checklist (CLAUDE.md) but not declared in DESCRIPTION.
+extra <- c("pkgdown", "urlchecker", "spelling")
+missing <- extra[!vapply(extra, requireNamespace, logical(1), quietly = TRUE)]
+if (length(missing) > 0) {
+  install.packages(missing)
+}

--- a/.claude/hooks/install-r-deps.R
+++ b/.claude/hooks/install-r-deps.R
@@ -2,11 +2,12 @@
 # Called from session-start.sh after system packages (r-base, pandoc, and
 # the compiled-package system libs) are in place.
 
-repos <- c(
-  P3M = "https://packagemanager.posit.co/cran/__linux__/noble/latest",
-  CRAN = "https://cloud.r-project.org"
-)
-options(repos = repos)
+# Posit Package Manager's index is reachable but its package downloads
+# redirect to a separate backend host, and R doesn't retry a failed
+# per-package download against the next listed repo — so a second repo here
+# doesn't add resilience, only a different single point of failure. Plain
+# CRAN alone is proven to work end to end (source builds, no redirects).
+options(repos = c(CRAN = "https://cloud.r-project.org"))
 
 if (!requireNamespace("devtools", quietly = TRUE)) {
   install.packages("devtools")

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Provisions R for Claude Code on the web sessions on this repo only.
+# Runs on every SessionStart; safe to re-run (apt/install.packages are
+# idempotent, and the fast-path check below skips work once the container's
+# base image already has R + pandoc, e.g. from a cached snapshot).
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+if ! command -v Rscript >/dev/null 2>&1 || ! command -v pandoc >/dev/null 2>&1; then
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update
+  apt-get install -y --no-install-recommends \
+    r-base \
+    pandoc \
+    build-essential \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    libxml2-dev \
+    libfontconfig1-dev \
+    libharfbuzz-dev \
+    libfribidi-dev \
+    libfreetype6-dev \
+    libpng-dev \
+    libtiff5-dev \
+    libjpeg-dev \
+    zlib1g-dev
+fi
+
+Rscript "$CLAUDE_PROJECT_DIR/.claude/hooks/install-r-deps.R"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -33,4 +33,12 @@ if ! command -v Rscript >/dev/null 2>&1 || ! command -v pandoc >/dev/null 2>&1; 
     libgit2-dev
 fi
 
+# R CMD check calls Sys.setlocale("LC_CTYPE", "en_US.UTF-8"); this container's
+# base image ships the `locales` package but hasn't generated that locale,
+# which turns "checking R files for syntax errors" into a false-positive
+# WARNING.
+if ! locale -a 2>/dev/null | grep -qi '^en_US\.utf8$'; then
+  locale-gen en_US.UTF-8
+fi
+
 Rscript "$CLAUDE_PROJECT_DIR/.claude/hooks/install-r-deps.R"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -28,7 +28,9 @@ if ! command -v Rscript >/dev/null 2>&1 || ! command -v pandoc >/dev/null 2>&1; 
     libpng-dev \
     libtiff5-dev \
     libjpeg-dev \
-    zlib1g-dev
+    zlib1g-dev \
+    libuv1-dev \
+    libgit2-dev
 fi
 
 Rscript "$CLAUDE_PROJECT_DIR/.claude/hooks/install-r-deps.R"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,22 @@ across machines and change on every R upgrade. If `Rscript` isn't on `PATH`,
 don't guess where R lives — stop and tell the user, and point them to add R's
 `bin` directory to `PATH` (or to supply the path to their `Rscript`).
 
+**Claude Code on the web / cloud sessions provision R automatically.** A
+`SessionStart` hook (`.claude/hooks/session-start.sh` + `install-r-deps.R`,
+registered in `.claude/settings.json`) installs r-base, pandoc, the
+compiled-package system libs, and the full R dev toolchain (devtools,
+roxygen2, testthat, pkgdown, urlchecker, spelling, plus DESCRIPTION's own
+Imports/Suggests) the first time a cloud session touches this repo. It needs
+`cloud.r-project.org` allowlisted in the environment's network policy (Custom
+network access → Allowed domains) — without it, the hook installs R itself
+fine but every package install fails. If `Rscript` still isn't on `PATH` in a
+cloud session, check the hook's output before concluding R is unavailable;
+the "stop and tell the user" rule above is for local sessions. Installs build
+from source (no binary mirror is reachable through the network policy), so
+the first cold container takes a while — expect the result to be cached in
+later sessions. None of this applies locally — Jonathan's machine manages its
+own R install per the rules above.
+
 **Never run R inline** (`Rscript -e "..."`) — Windows shell quoting mangles it.
 Always write the R code to a temp file and execute that file:
 
@@ -34,14 +50,20 @@ Run these in order after changing R source or roxygen comments:
 3. `devtools::check()` — `R CMD check`. Target: **0 errors, 0 warnings**. The
    **only** accepted NOTE is the proprietary-license one
    (`Non-standard license specification: file LICENSE`). Any other NOTE is a
-   regression — investigate it.
+   regression — investigate it. In a cloud session, expect two additional
+   NOTEs that aren't regressions: installed package size (the bundled fonts
+   are 4.8Mb) and "unable to verify current time" (the future-timestamp check
+   needs a network host this environment's policy blocks). Anything beyond
+   those three is worth investigating same as locally.
 4. `pkgdown::build_site()` — rebuilds the site into `docs/`. Two gotchas when
    running via standalone Rscript (no RStudio):
    - pkgdown/rmarkdown need Pandoc, which a bare `Rscript` may not find. If a build
      fails with "Pandoc not available," point R at a bundled copy via
      `Sys.setenv(RSTUDIO_PANDOC = <dir>)` — Quarto and RStudio each ship one in a
      `tools` directory. Locate the copy on the current machine rather than
-     assuming a path.
+     assuming a path. (Cloud sessions get a system `pandoc` from the
+     SessionStart hook, already on `PATH` — this workaround is for local
+     sessions without RStudio/Quarto installed.)
    - `build_site()` re-knits `vignettes/articles/branded-themes.Rmd`, which needs
      tidycensus + a Census API key + network and will fail offline. For doc/theme
      changes, rebuild only what changed instead:


### PR DESCRIPTION
## Summary

- Adds a `SessionStart` hook (`.claude/hooks/session-start.sh` + `install-r-deps.R`, registered in `.claude/settings.json`) that provisions R, pandoc, and the full dev toolchain automatically the first time a Claude Code on the web / cloud session opens this repo — so Phase 2 (and later) sessions can run the CLAUDE.md dev loop without Jonathan having R set up locally.
- Documents the hook in `CLAUDE.md`'s "Running R" section: the `cloud.r-project.org` network-policy prerequisite, and two extra `R CMD check` NOTEs that show up only in this sandboxed environment (package size, future-timestamp) and aren't regressions.

Scoped to this repo only — the hook checks `$CLAUDE_CODE_REMOTE` and no-ops on Jonathan's local machine.

## What it installs

- System packages via apt: `r-base`, `pandoc`, `build-essential`, and the compiled-package system libs (curl/ssl/xml2/fontconfig/harfbuzz/fribidi/freetype/png/tiff/jpeg/zlib/libuv/libgit2).
- Generates the `en_US.UTF-8` locale (`R CMD check` needs it; the base image ships `locales` but doesn't generate it).
- R packages via `devtools::install_dev_deps()`: devtools, remotes, roxygen2, testthat, plus DESCRIPTION's own Imports/Suggests, and separately pkgdown/urlchecker/spelling for the release checklist.

## Why it looks the way it does

This took a few iterations to get right, worth recording:

- Posit Package Manager's index is reachable through the network policy, but its actual package downloads redirect to `rspm-sync.rstudio.com`, a separate host that isn't allowlisted — and R doesn't retry a failed per-package download against the next listed repo. So the install repos list is CRAN-only (`cloud.r-project.org`); a second repo here would just trade one single point of failure for another, not add resilience.
- `fs` and `gert` (deep in devtools' dependency tree) need `libuv1-dev` and `libgit2-dev` respectively to compile — without them the failure cascades all the way up through rmarkdown/shiny/bslib/usethis/pkgdown/roxygen2/testthat/devtools.
- `devtools::install_dev_deps()` shells out to `remotes` internally, which isn't a hard dependency of devtools itself.
- No binary mirror is reachable through this network policy, so everything compiles from source — the first cold container takes a while (dozens of packages, some with real C/C++ builds like `stringi`). Container state is cached afterward per the session-start-hook skill's guidance.

## Validation

Ran the full CLAUDE.md dev loop against the installed toolchain:

- `devtools::document()` — clean, no diff to `NAMESPACE`/`man/` (roxygen output unchanged).
- `devtools::test()` — `189/189` passing, 0 fail/warn/skip.
- `devtools::check()` — **0 errors, 0 warnings**, 2 NOTEs (package size from bundled fonts; future-timestamp check blocked by network policy) — neither is a regression, both documented in the CLAUDE.md update.

## Test plan

- [x] Hook script executed directly in a live container with `CLAUDE_CODE_REMOTE=true`; confirmed R/pandoc/devtools/roxygen2/testthat/pkgdown/urlchecker/spelling all installed and importable.
- [x] Full `document()` → `test()` → `check()` loop run against the resulting toolchain (see Validation above).
- [ ] Confirm in an actual fresh cloud session once merged to `main` (new session branches are cut from `main`, so the hook only reaches them after this merges).

Not merging this myself — leaving that decision to Jonathan.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gb8stsMADxyx8v2VYEzEeq)_